### PR TITLE
feat: 为右键doro菜单添加退出桌宠选项

### DIFF
--- a/src/MainLayer/__init__.py
+++ b/src/MainLayer/__init__.py
@@ -1,7 +1,9 @@
+import random
 from ..system_tray import SystemTray
 from ..config import Config
 from ..ResourceManager import ResourceManager
 from ..pet_window import PetWindow
+from ..auto_typehint import GifHint, MusicHint
 
 
 class MainLayer:
@@ -14,6 +16,34 @@ class MainLayer:
         )
         self.pet_window: PetWindow = PetWindow(self.config, self)
         self.system_tray: SystemTray = SystemTray(self.pet_window, self.config, self)
+
+    # ---------------- 资源统一接口封装 ----------------
+    def get_gif(
+        self, key: GifHint.GifDirLiteral
+    ):  # 具体字面量类型在 ResourceManager 已声明
+        return self.resource_manager.get_gif(key)
+
+    def get_all_gif(self):
+        return self.resource_manager.get_all_gif()
+
+    def get_music(self, key: MusicHint.MusicDirLiteral):
+        return self.resource_manager.get_music(key)
+
+    def get_all_music(self):
+        return self.resource_manager.get_all_music()
+
+    # 常用便捷接口
+    def random_gif(self, key: GifHint.GifDirLiteral):
+        files = self.get_gif(key)
+        if files:
+            return random.choice(files)
+        return None
+
+    def random_music(self, key: MusicHint.MusicDirLiteral):
+        files = self.get_music(key)
+        if files:
+            return random.choice(files)
+        return None
 
 
 __all__ = [

--- a/src/pet_window.py
+++ b/src/pet_window.py
@@ -1,8 +1,8 @@
 import os
 import random
-from typing import Dict, List, Optional, TYPE_CHECKING
+from typing import Dict, Optional, TYPE_CHECKING
 from PySide6.QtCore import Qt, QSize, QUrl, QEvent, Signal
-from PySide6.QtGui import QMovie, QIcon, QTransform
+from PySide6.QtGui import QMovie, QTransform, QPainter, QPaintEvent
 from PySide6.QtMultimedia import QMediaPlayer, QAudioOutput
 from PySide6.QtWidgets import (
     QMainWindow,
@@ -20,6 +20,32 @@ if TYPE_CHECKING:
     from MainLayer import MainLayer
 
 
+class PetAnimationLabel(QLabel):
+    """自定义动画标签: 通过重写 paintEvent 实现镜像而不逐帧信号处理, 避免残影"""
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self._mirror: bool = False
+
+    def set_mirror(self, mirror: bool):
+        if self._mirror != mirror:
+            self._mirror = mirror
+            self.update()
+
+    def paintEvent(self, event: QPaintEvent):  # type: ignore[override]
+        movie = self.movie()
+        if movie and movie.state() != QMovie.MovieState.NotRunning:
+            frame = movie.currentPixmap()
+            if self._mirror and not frame.isNull():
+                frame = frame.transformed(QTransform().scale(-1, 1))
+            painter = QPainter(self)
+            x = (self.width() - frame.width()) // 2
+            y = (self.height() - frame.height()) // 2
+            painter.drawPixmap(x, y, frame)
+        else:
+            super().paintEvent(event)
+
+
 class PetWindow(QMainWindow):
     """宠物主窗口类"""
 
@@ -32,40 +58,25 @@ class PetWindow(QMainWindow):
         self.movie_cache: Dict[str, QMovie] = {}
         self.main_layer: MainLayer = main_layer
 
-        # 初始化UI组件
-        self._setup_ui()
-        # 初始化窗口属性
-        self._setup_window()
-        # 加载资源
-        self._load_resources()
-        # 初始化音频
-        self._setup_audio()
-        # 初始化状态机
-        self._setup_state_machine()
+        # 分步骤初始化
+        self._setup_ui()            # 基础 UI 组件 & 动画标签 & 信息面板
+        self._setup_window()        # 窗口 flag 与尺寸等
+        self._load_resources()      # 加载 GIF / 资源
+        self._setup_audio()         # 音频
+        self._setup_state_machine() # 状态机
+        self.update_config()        # 根据配置应用显示/主题/窗口模式
 
-    def _setup_window(self):
-        """设置窗口属性"""
-        self.setWindowTitle("doro")
-
-        self.set_info_visible()
-        self.set_always_on_top(self.config.config["Window"]["StaysOnTop"])
-        self.set_frameless_mode(self.config.config["Window"]["Frameless"])
-
-        # 设置窗口图标
-        icon_path = Config.PATH_CONFIG["Icon"]["RelativePath"]
-        if os.path.exists(icon_path):
-            self.setWindowIcon(QIcon(icon_path))
-
+    # ---------------- Internal setup methods -----------------
     def _setup_ui(self):
-        """初始化UI组件"""
-        self.main_widget = QWidget()
+        """初始化主部件/布局/动画标签/信息窗口"""
+        self.main_widget = QWidget(self)
         self.setCentralWidget(self.main_widget)
         self.main_layout = QHBoxLayout(self.main_widget)
         self.main_layout.setContentsMargins(0, 0, 0, 0)
-        self.main_layout.setSpacing(0)
+        self.main_layout.setSpacing(4)
 
         # 动画标签
-        self.animation_label = QLabel()
+        self.animation_label = PetAnimationLabel(self.main_widget)
         self.animation_label.setFixedSize(
             self.config.config["Window"]["Width"],
             self.config.config["Window"]["Height"],
@@ -75,12 +86,49 @@ class PetWindow(QMainWindow):
         # 信息窗口
         self._setup_info_widget()
 
-        # 添加组件到布局
+        # 放入布局 (顺序: 动画 -> 信息)
         self.main_layout.addWidget(self.animation_label)
         self.main_layout.addWidget(self.info_widget)
 
-        # 更新窗口大小
+    def _setup_window(self):
+        """窗口基础属性"""
+        self.setWindowTitle("Doro")
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self.setWindowFlags(
+            Qt.WindowType.Tool
+            | Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+        )
         self._update_window_size()
+
+    def _load_gif_files(self):
+        """预加载 GIF (可按需懒加载, 这里只收集路径)"""
+        self.gif_files = self.main_layer.resource_manager.get_all_gif()
+
+    def _load_resources(self):
+        """加载资源文件"""
+        self._load_gif_files()
+        # 鼠标跟踪 & 屏幕几何
+        self.setMouseTracking(True)
+        self.screen_geometry = self.screen().availableGeometry()
+
+    def _setup_audio(self):
+        """初始化音频系统"""
+        self.audio_player = QMediaPlayer()
+        self.audio_output = QAudioOutput()
+        self.audio_player.setAudioOutput(self.audio_output)
+        music_root = Config.PATH_CONFIG["Resources"]["Music"].get("DoubleClick")
+        if music_root and os.path.exists(music_root):
+            candidates = self.main_layer.resource_manager.get_music("DoubleClick")
+            if candidates:
+                self.audio_player.setSource(QUrl.fromLocalFile(random.choice(candidates)))
+                self.audio_player.stop()
+
+    def _setup_state_machine(self):
+        self.state_machine = StateMachine(self)
+        self.state_machine.ui_components["cpu_label"] = self.cpu_label
+        self.state_machine.ui_components["memory_label"] = self.memory_label
+        self.state_machine.ui_components["network_label"] = self.network_label
 
     def _setup_info_widget(self):
         """初始化信息窗口"""
@@ -104,84 +152,37 @@ class PetWindow(QMainWindow):
 
         self.update_theme()
 
-    def _load_resources(self):
-        """加载资源文件"""
-        self._load_gif_files()
-
-        # 鼠标交互属性
-        self.setMouseTracking(True)
-
-        # 屏幕几何信息
-        self.screen_geometry = self.screen().availableGeometry()
-
-    def _setup_audio(self):
-        """初始化音频系统"""
-        self.audio_player = QMediaPlayer()
-        self.audio_output = QAudioOutput()
-        self.audio_player.setAudioOutput(self.audio_output)
-
-        if os.path.exists(Config.PATH_CONFIG["Resources"]["Music"]["DoubleClick"]):
-            self.audio_player.setSource(
-                QUrl.fromLocalFile(
-                    random.choice(
-                        self.main_layer.resource_manager.get_music("DoubleClick")
-                    )
-                )
-            )
-            self.audio_player.stop()
-
-    def _setup_state_machine(self):
-        """初始化状态机"""
-        self.state_machine = StateMachine(self)
-
-        self.state_machine.ui_components["cpu_label"] = self.cpu_label
-        self.state_machine.ui_components["memory_label"] = self.memory_label
-        self.state_machine.ui_components["network_label"] = self.network_label
+    # -------------------- Info widget --------------------
 
     def _update_window_size(self):
-        """更新窗口大小"""
+        """根据是否显示信息窗口调整主窗口尺寸"""
+        pet_w = self.config.config["Window"]["Width"]
+        pet_h = self.config.config["Window"]["Height"]
+        self.animation_label.setFixedSize(pet_w, pet_h)
         if self.config.config["Info"]["ShowInfo"]:
-            total_width = (
-                self.config.config["Window"]["Width"]
-                + self.info_widget.width()
-                + self.main_layout.spacing()
-            )
+            total_width = pet_w + self.info_widget.width() + self.main_layout.spacing()
         else:
-            total_width = self.config.config["Window"]["Width"]
-        total_height = self.config.config["Window"]["Height"]
-        self.setFixedSize(total_width, total_height)
-
-    def _load_gif_files(self):
-        """加载GIF文件"""
-        for gif_path in self.main_layer.resource_manager.get_all_gif():
-            self.movie_cache[gif_path] = QMovie(gif_path)
-            self.movie_cache[gif_path].stop()
-
-    def _load_gif_from_folder(self, folder_path: str) -> List[str]:
-        """从文件夹加载GIF文件"""
-        if not os.path.exists(folder_path):
-            print(f"路径不存在: {folder_path}")
-            return []
-        return [
-            os.path.join(folder_path, f)
-            for f in os.listdir(folder_path)
-            if f.endswith(".gif")
-        ]
+            total_width = pet_w
+        self.resize(total_width, max(pet_h, self.info_widget.height()))
 
     # ========== 公共方法 ==========
     def play_gif(self, gif_path: str, mirror: bool = False):
-        """播放GIF动画"""
+        """播放 GIF 动画 (mirror=True 镜像)
+
+        使用自定义标签 paintEvent 镜像避免残影。
+        """
         if not os.path.exists(gif_path):
             print(f"GIF文件不存在: {gif_path}")
             return
 
+        # 停止旧动画 (不必清除标签, 由新 movie 覆盖)
         if self.movie:
             self.movie.stop()
-            self.animation_label.clear()
 
-        movie = self.movie_cache.get(gif_path, None)
+        movie = self.movie_cache.get(gif_path)
         if movie is None:
             movie = QMovie(gif_path)
+            movie.setCacheMode(QMovie.CacheMode.CacheAll)
             self.movie_cache[gif_path] = movie
 
         movie.setScaledSize(
@@ -192,23 +193,12 @@ class PetWindow(QMainWindow):
         )
         self.movie = movie
 
-        if mirror:
-            # 连接帧变化信号，实现逐帧镜像
-            def update_frame():
-                if not self.movie:
-                    return
-                frame = self.movie.currentPixmap()
-                mirrored = frame.transformed(QTransform().scale(-1, 1))
-                self.animation_label.setPixmap(mirrored)
-
-            self.movie.frameChanged.connect(update_frame)
-            self.movie.start()
-        else:
-            self.animation_label.setMovie(self.movie)
-            self.movie.start()
+        # 设置标签 movie 并切换镜像模式
+        self.animation_label.setMovie(self.movie)
+        self.animation_label.set_mirror(mirror)
+        self.movie.start()
 
     def set_info_visible(self):
-        """设置信息窗口可见性"""
         self.info_widget.setVisible(self.config.config["Info"]["ShowInfo"])
         self._update_window_size()
 
@@ -240,23 +230,20 @@ class PetWindow(QMainWindow):
         self.show()
 
     def update_theme(self):
-        """更新主题颜色"""
         colors = self.config.get_theme_colors()
-
-        # 设置信息窗口样式
         self.info_widget.setStyleSheet(generate_pet_info_css(colors))
         self.info_widget.setObjectName("PetInfoWindowInfoWidget")
 
     def update_config(self):
-        """更新配置"""
-        # 更新信息框显示状态
+        # 信息窗口
         self.set_info_visible()
-        # 更新窗口模式
-        self.set_always_on_top(self.config.config["Window"]["StaysOnTop"])
-        self.set_frameless_mode(self.config.config["Window"]["Frameless"])
-        # 更新主题
+        # 窗口模式 / 置顶
+        self.set_always_on_top(self.config.config["Window"].get("StaysOnTop", True))
+        self.set_frameless_mode(self.config.config["Window"].get("Frameless", True))
+        # 主题
         self.update_theme()
-        self.state_machine.update_config()
+        if hasattr(self, "state_machine"):
+            self.state_machine.update_config()
 
     # ========== 事件处理 ==========
     def event(self, event: QEvent) -> bool:

--- a/src/state/clicked_state_handler.py
+++ b/src/state/clicked_state_handler.py
@@ -1,5 +1,4 @@
 import os
-import random
 from PySide6.QtCore import QTimer, QUrl, QEvent, Qt
 from PySide6.QtGui import QMouseEvent
 
@@ -17,15 +16,13 @@ class ClickedStateHandler(StateHandler):
         return super()._init_state()
 
     def on_enter(self):
-        self.main_layer.pet_window.play_gif(
-            random.choice(self.main_layer.resource_manager.get_gif("Click"))
-        )
+        gif_path = self.main_layer.random_gif("Click")
+        if gif_path:
+            self.main_layer.pet_window.play_gif(gif_path)
         if os.path.exists(Config.PATH_CONFIG["Resources"]["Music"]["DoubleClick"]):
             self.main_layer.pet_window.audio_player.setSource(
                 QUrl.fromLocalFile(
-                    random.choice(
-                        self.main_layer.resource_manager.get_music("DoubleClick")
-                    )
+                    self.main_layer.random_music("DoubleClick") or ""
                 )
             )
             self.main_layer.pet_window.audio_player.play()

--- a/src/state/dragging_state_handler.py
+++ b/src/state/dragging_state_handler.py
@@ -1,4 +1,3 @@
-import random
 from typing import Optional
 from PySide6.QtCore import Qt, QEvent, QTimer, QPoint
 from PySide6.QtGui import QMouseEvent
@@ -23,9 +22,9 @@ class DraggingStateHandler(StateHandler):
             return False
         self.is_dragging = True
         self.debounce_end_dragging()
-        self.main_layer.pet_window.play_gif(
-            random.choice(self.main_layer.resource_manager.get_gif("Drag"))
-        )
+        gif_path = self.main_layer.random_gif("Drag")
+        if gif_path:
+            self.main_layer.pet_window.play_gif(gif_path)
         self.old_pos = None
         self.state_machine.timers["monitor"].stop()
         return True

--- a/src/state/eating_state_handler.py
+++ b/src/state/eating_state_handler.py
@@ -1,4 +1,3 @@
-import random
 from PySide6.QtCore import QTimer, QEvent, Qt
 from PySide6.QtGui import QMouseEvent
 from .base_state import StateHandler, PetState
@@ -15,9 +14,9 @@ class EatingStateHandler(StateHandler):
 
     def on_enter(self):
         self.eating_end_timer.start(3000)
-        self.main_layer.pet_window.play_gif(
-            random.choice(self.main_layer.resource_manager.get_gif("Eat"))
-        )
+        gif_path = self.main_layer.random_gif("Eat")
+        if gif_path:
+            self.main_layer.pet_window.play_gif(gif_path)
 
     def on_exit(self):
         self.eating_end_timer.stop()

--- a/src/state/hungry_state_handler.py
+++ b/src/state/hungry_state_handler.py
@@ -1,4 +1,3 @@
-import random
 from PySide6.QtCore import QTimer, QEvent, Qt
 from PySide6.QtGui import QMouseEvent
 from PySide6.QtWidgets import QLabel
@@ -31,9 +30,9 @@ class HungryStateHandler(StateHandler):
             return False
         elif self.state_machine.state_stack[-1] == PetState.DRAGGING:
             return False
-        self.main_layer.pet_window.play_gif(
-            random.choice(self.main_layer.resource_manager.get_gif("Hungry"))
-        )
+        gif_path = self.main_layer.random_gif("Hungry")
+        if gif_path:
+            self.main_layer.pet_window.play_gif(gif_path)
 
     def on_exit(self):
         return super().on_exit()

--- a/src/state/moving_state_handler.py
+++ b/src/state/moving_state_handler.py
@@ -81,11 +81,12 @@ class MovingStateHandler(StateHandler):
     def prepare_movement(self):
         """准备移动动画和方向，自动适配 GIF 方向"""
         self.move_direction = random.choice(["left", "right", "up", "down"])
-        move_gif = random.choice(self.main_layer.resource_manager.get_gif("Move"))
+        move_gif = self.main_layer.random_gif("Move")
 
         # 右移时镜像
         mirror = self.move_direction == "right"
-        self.main_layer.pet_window.play_gif(move_gif, mirror=mirror)
+        if move_gif:
+            self.main_layer.pet_window.play_gif(move_gif, mirror=mirror)
 
         move_duration = random.randint(5000, 10000)
         self.is_moving = True

--- a/src/state/normal_state_handler.py
+++ b/src/state/normal_state_handler.py
@@ -1,5 +1,4 @@
 import os
-import random
 from PySide6.QtCore import QEvent, Qt, QTimer
 from PySide6.QtGui import QMouseEvent, QIcon
 from PySide6.QtWidgets import QMessageBox
@@ -26,8 +25,9 @@ class NormalStateHandler(StateHandler):
         self.normal_timer.start(
             1000 * self.main_layer.config.config["Random"]["Interval"]
         )
-        gif_path = random.choice(self.main_layer.resource_manager.get_gif("Common"))
-        self.main_layer.pet_window.play_gif(gif_path)
+        gif_path = self.main_layer.random_gif("Common")
+        if gif_path:
+            self.main_layer.pet_window.play_gif(gif_path)
 
     def on_exit(self):
         self.normal_timer.stop()
@@ -63,8 +63,9 @@ class NormalStateHandler(StateHandler):
 
     def change_gif(self):
         if self.state_machine.current_state == PetState.NORMAL:
-            gif_path = random.choice(self.main_layer.resource_manager.get_gif("Common"))
-            self.main_layer.pet_window.play_gif(gif_path)
+            gif_path = self.main_layer.random_gif("Common")
+            if gif_path:
+                self.main_layer.pet_window.play_gif(gif_path)
 
     def handle_about(self):
         """处理关于"""

--- a/src/state/normal_state_handler.py
+++ b/src/state/normal_state_handler.py
@@ -1,7 +1,7 @@
 import os
 from PySide6.QtCore import QEvent, Qt, QTimer
 from PySide6.QtGui import QMouseEvent, QIcon
-from PySide6.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QMessageBox, QApplication
 from ..setting_gui import SettingsDialog
 from .base_state import StateHandler, menu_item, PetState
 from ..style_sheet import (
@@ -13,6 +13,7 @@ from ..pages import get_page
 
 @menu_item("关于Doro", "handle_about", isGlobal=0)
 @menu_item("设置", "handle_settings", separator=True, isGlobal=1)
+@menu_item("退出桌宠", "handle_quit", isGlobal=1)
 class NormalStateHandler(StateHandler):
     """正常状态处理器"""
 
@@ -74,6 +75,14 @@ class NormalStateHandler(StateHandler):
     def handle_settings(self):
         """处理设置"""
         self.show_settings()
+
+    def handle_quit(self):
+        print("Doro will miss you!")
+
+        # 获取程序实例
+        app = QApplication.instance()
+        if app is not None:
+            app.quit()
 
     def show_settings(self):
         """显示设置对话框"""


### PR DESCRIPTION
现在我们可以直接右键doro本体，在菜单栏中退出桌宠程序，而不需要去系统托盘了
<img width="710" height="517" alt="1755425294" src="https://github.com/user-attachments/assets/e2404e11-89a2-4b9d-b308-bbd7558ed652" />
